### PR TITLE
[DAT-22164] Update CI workflow branch trigger from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: 0 0 * * 0
 


### PR DESCRIPTION
## Summary
- Updated `.github/workflows/ci.yml` push trigger from `master` to `main`
- `.ci/check-pr-no-readme.sh` fetches from upstream `docker-library/docs.git master` — left unchanged (upstream repo)

## Post-merge steps
Rename default branch from `master` to `main` in GitHub repo settings.

Jira: [DAT-22164](https://datical.atlassian.net/browse/DAT-22164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)